### PR TITLE
[EVPN]: Ignore update tunnel port status to asic db

### DIFF
--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -7901,6 +7901,9 @@ void Meta::meta_sai_on_port_state_change_single(
             valid = true;
             break;
 
+       case SAI_OBJECT_TYPE_TUNNEL:
+           break;
+
         default:
 
             SWSS_LOG_ERROR("data.port_id %s has unexpected type: %s, expected PORT, BRIDGE_PORT or LAG",


### PR DESCRIPTION
**What did I do?**
1.Ignore update tunnel port status to asic db.
**How to verify?**
test report log without "meta_sai_on_port_state_change_single: data.port_id oid:0x2a000000000b5f has unexpected type: SAI_OBJECT_TYPE_TUNNEL, expected PORT, BRIDGE_PORT or LAG" error log.